### PR TITLE
Skip internal option setting

### DIFF
--- a/Grammar.pp
+++ b/Grammar.pp
@@ -44,7 +44,7 @@
 
 
 // Skip.
-%skip   nl                       \n
+%skip   nl                       \n|\(\?\-?[imsx]\)
 
 // Character classes.
 %token  negative_class_          \[\^


### PR DESCRIPTION
Should fix https://github.com/hoaproject/Regex/issues/10.

Since it is a laborious task to manage internal option setting, I propose to just skip them for now. In this case, regular expressions are going to be parsed normally, but the generation is not going to take into account this information.

Thoughts?
