### PR TITLE
Fix non-breaking space character encoding.

### DIFF
--- a/Visitor/Isotropic.php
+++ b/Visitor/Isotropic.php
@@ -264,8 +264,8 @@ class Isotropic implements Visitor\Visit
 
                             case 'h':
                                 $h = [
-                                    chr(0x0009),
-                                    chr(0x0020),
+                                    Ustring::fromCode(0x0009),
+                                    Ustring::fromCode(0x0020),
                                     Ustring::fromCode(0x00a0)
                                 ];
 
@@ -273,10 +273,10 @@ class Isotropic implements Visitor\Visit
 
                             case 'v':
                                 $v = [
-                                    chr(0x000a),
-                                    chr(0x000b),
-                                    chr(0x000c),
-                                    chr(0x000d)
+                                    Ustring::fromCode(0x000a),
+                                    Ustring::fromCode(0x000b),
+                                    Ustring::fromCode(0x000c),
+                                    Ustring::fromCode(0x000d)
                                 ];
 
                                 return $v[$this->_sampler->getInteger(0, count($v) -1)];
@@ -288,7 +288,7 @@ class Isotropic implements Visitor\Visit
                                     [0x5f]
                                 );
 
-                                return chr($w[$this->_sampler->getInteger(0, count($w) - 1)]);
+                                return Ustring::fromCode($w[$this->_sampler->getInteger(0, count($w) - 1)]);
 
                             default:
                                 return '?';
@@ -304,7 +304,7 @@ class Isotropic implements Visitor\Visit
                                 [0x5f]
                             );
 
-                            return chr($w[$this->_sampler->getInteger(0, count($w) - 1)]);
+                            return Ustring::fromCode($w[$this->_sampler->getInteger(0, count($w) - 1)]);
                         }
 
                         return

--- a/Visitor/Isotropic.php
+++ b/Visitor/Isotropic.php
@@ -266,7 +266,7 @@ class Isotropic implements Visitor\Visit
                                 $h = [
                                     chr(0x0009),
                                     chr(0x0020),
-                                    chr(0x00a0)
+                                    Ustring::fromCode(0x00a0)
                                 ];
 
                                 return $h[$this->_sampler->getInteger(0, count($h) -1)];


### PR DESCRIPTION
Since the character code is > 128, the string representation of the character must be encoded in UTF-8 and not in ISO 8859-1 or other default value.

Related to https://github.com/hoaproject/Compiler/pull/27#issuecomment-129319732.